### PR TITLE
Ensure icon fits in fab

### DIFF
--- a/src/fab.android.ts
+++ b/src/fab.android.ts
@@ -47,7 +47,7 @@ export class Fab extends FloatingActionButtonBase {
     this.nativeView.setOnClickListener(clickListener);
     (<any>this.nativeView).clickListener = clickListener;
     // setting scale type statically for now - can add configuration options with next release after confirming fixes for other icons sizes
-    this.android.setScaleType(android.widget.ImageView.ScaleType.CENTER);
+    this.android.setScaleType(android.widget.ImageView.ScaleType.CENTER_INSIDE);
   }
 
   [backgroundColorProperty.getDefault](): android.content.res.ColorStateList {


### PR DESCRIPTION
Centering the icon makes it no longer scale to fit. CENTER_INSIDE scales as well as centers it.