### PR TITLE
fix: Icon tint

### DIFF
--- a/src/fab-common.ts
+++ b/src/fab-common.ts
@@ -236,3 +236,8 @@ export const androidScaleTypeProperty = new Property<
   affectsLayout: true,
 });
 androidScaleTypeProperty.register(FloatingActionButtonBase);
+export const colorProperty = new Property({
+  name: 'color',
+  valueConverter: (v) => new Color(v),
+});
+colorProperty.register(FloatingActionButtonBase);

--- a/src/fab.android.ts
+++ b/src/fab.android.ts
@@ -78,6 +78,22 @@ export class Fab extends FloatingActionButtonBase {
     // NOOP
   }
 
+  [colorProperty.setNative](value) {
+    let newValue;
+    if (value instanceof Color) {
+        newValue = android.content.res.ColorStateList.valueOf(value.android);
+    }
+    else {
+        newValue = value;
+    }
+    try {
+        this.nativeView.setSupportImageTintList(newValue);
+    }
+    catch (err) {
+        console.log(`Error setNative colorProperty: `, err);
+    }
+  }
+
   [rippleColorProperty.setNative](value: Color) {
     this.nativeView.setRippleColor(value.android);
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,5 +11,6 @@ export declare class Fab extends View {
     | 'scale';
   public hideAnimationDuration: number;
   public rippleColor: Color;
+  public color: Color;
   public icon: string;
 }


### PR DESCRIPTION
Fix to the icon being always tinted black in Android. This should solve #102 and #128. 

I'm not sure if this is the best solution but it's still a solution.